### PR TITLE
Fix seg fault on osx 10.10 with gcc 4.9.3

### DIFF
--- a/src/pflotran/pm_ufd_decay.F90
+++ b/src/pflotran/pm_ufd_decay.F90
@@ -119,6 +119,8 @@ function PMUFDDecayCreate()
   nullify(PMUFDDecayCreate%isotope_list)
   nullify(PMUFDDecayCreate%element_list)
 
+  call PMBaseInit(PMUFDDecayCreate)
+
 end function PMUFDDecayCreate
 
 ! ************************************************************************** !

--- a/src/pflotran/pm_waste_form.F90
+++ b/src/pflotran/pm_waste_form.F90
@@ -326,6 +326,8 @@ function PMWFCreate()
   nullify(PMWFCreate%mechanism_list)  
   PMWFCreate%print_mass_balance = PETSC_FALSE
 
+  call PMBaseInit(PMWFCreate)
+
 end function PMWFCreate
 
 ! ************************************************************************** !


### PR DESCRIPTION
Adds call to PMBaseInit() for pm_ufd_decay and pm_waste_form to avoid
segmentation violation on osx 10.10 with gcc 4.9.3